### PR TITLE
1.1.9_05

### DIFF
--- a/keybind.lua
+++ b/keybind.lua
@@ -26,16 +26,10 @@ local Text = require('widgets/text')
 local TEMPLATES = require('widgets/redux/templates')
 local OptionsScreen = require('screens/redux/optionsscreen')
 
-local KEYBOARD = { -- for missing definitions in constants.lua
-  KEY_QUOTE = 39,
-  KEY_BACKQUOTE = 96,
-}
+local KEYBOARD = { KEY_QUOTE = 39, KEY_BACKQUOTE = 96 } -- for missing definitions in constants.lua
 
-local MOUSE = { -- mouse button emoji => code number
-  ['\238\132\130'] = 1002, -- Middle Mouse Button
-  ['\238\132\131'] = 1005, -- Mouse Button 4
-  ['\238\132\132'] = 1006, -- Mouse Button 5
-}
+-- emoji of Middle Mouse Button, Mouse Button 4 and 5 => code number
+local MOUSE = { ['\238\132\130'] = 1002, ['\238\132\131'] = 1005, ['\238\132\132'] = 1006 }
 
 -- "KEY_*" and mouse button emoji => code number or nil
 local function Raw(key) return KEYBOARD[key] or MOUSE[key] or G.rawget(G, key) end
@@ -66,11 +60,13 @@ for _, config in ipairs(modinfo.configuration_options) do
 end
 
 -- initialize binds
-AddGamePostInit(function()
-  for name, _ in pairs(is_keybind) do
-    KeyBind(name, Raw(GetModConfigData(name)))
+local function InitBindings()
+  for _, config in pairs(configs) do
+    KeyBind(config.name, Raw(GetModConfigData(config.name, true)))
   end
-end)
+end
+local AddInit = modinfo.client_only_mod and AddGamePostInit or AddPlayerPostInit
+AddInit(InitBindings)
 
 --------------------------------------------------------------------------------
 -- Button widget to show and change bind
@@ -262,12 +258,12 @@ end)
 -- Add mod name header and keybind entries to the list in "Options > Controls"
 AddClassPostConstruct('screens/redux/optionsscreen', function(self)
   -- rtk0c: Reusing the same list is fine, per the current logic in ScrollableList:SetList();
-  -- Don't call ScrollableList:AddItem() one by one to avoid wasting time recalcuating the list size.
+  -- Don't call ScrollableList:AddItem() one by one to avoid wasting time recalculating the list size.
   local list = self.kb_controllist
   local items = list.items
   if #configs > 0 then table.insert(items, list:AddChild(Header(modinfo.name))) end
   for _, config in ipairs(configs) do
-    _key[config] = GetModConfigData(config.name)
+    _key[config] = GetModConfigData(config.name, true)
     table.insert(items, list:AddChild(BindEntry(self, config)))
   end
   list:SetList(items, true)
@@ -290,6 +286,6 @@ function OptionsScreen:Save(...)
     KeyBind(config.name, Raw(key)) -- let mod change bind
     G.KnownModIndex:SetConfigurationOption(modname, config.name, key)
   end
-  G.KnownModIndex:SaveHostConfiguration(modname) -- save to disk
+  G.KnownModIndex:SaveConfigurationOptions(function() end, modname, modinfo.configuration_options, true) -- save to disk
   return OldSave(self, ...)
 end

--- a/modinfo.lua
+++ b/modinfo.lua
@@ -1,16 +1,17 @@
 -- 250324 VanCa: Integrate KeyBind UI by 李皓奇
 -- https://github.com/liolok/DST-KeyBind-UI
 
-version = "1.1.9_04"
+version = "1.1.9_05"
 name = "Snapping tills A WHOLE FIELD v" .. version
 description =
     [[Aligns plowing to the grid.
-
 LeftShift + RightClick: Launch auto tilling on a tile.
 LeftShift + DoubleRightClick: Launch auto tilling on multi tiles.
-Key "L": Toggle snap modes: off / optimized / 4x4 / 3x3 / 2x2 / hexagon.
-Key ";": Toggle Intercropping mode: off / intercropping 2-3-4 types of plants per tile.
-Optimized mode checks for an adjacent soil tile, if not found adjacent soil tile then uses 4x4 else uses 3x3. You can bind key in configure mod.
+
+Hotkey configs:
+Toggle Snap modes: off | optimized | 4x4 | 3x3 | 2x2 | Hexagon.
+Toggle Intercropping modes: Auto | 2 ~ 4 types of plants per tile.
+(Check workshop page for detail about Optimized and Auto mode)
 
 Important:
     "Geometric Placement" has priority, so that to use this mod,
@@ -33,18 +34,46 @@ dst_compatible = true
 all_clients_require_mod = false
 client_only_mod = true
 
-local keyboard = { -- from STRINGS.UI.CONTROLSSCREEN.INPUTS[1] of strings.lua, need to match constants.lua too.
-    { 'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12', 'Print', 'ScrolLock', 'Pause' },
-    { '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' },
-    { 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z' },
-    { 'Escape', 'Tab', 'CapsLock', 'LShift', 'LCtrl', 'LSuper', 'LAlt' },
-    { 'Space', 'RAlt', 'RSuper', 'RCtrl', 'RShift', 'Enter', 'Backspace' },
-    { 'BackQuote', 'Tilde', 'Minus', 'Equals', 'LeftBracket', 'RightBracket' },
-    { 'Backslash', 'Semicolon', 'Quote', 'Period', 'Slash' }, -- punctuation
-    { 'Up', 'Down', 'Left', 'Right', 'Insert', 'Delete', 'Home', 'End', 'PageUp', 'PageDown' }, -- navigation
+local keyboard = {
+    -- from STRINGS.UI.CONTROLSSCREEN.INPUTS[1] of strings.lua, need to match constants.lua too.
+    {"F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12", "Print", "ScrolLock", "Pause"},
+    {"1", "2", "3", "4", "5", "6", "7", "8", "9", "0"},
+    {
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F",
+        "G",
+        "H",
+        "I",
+        "J",
+        "K",
+        "L",
+        "M",
+        "N",
+        "O",
+        "P",
+        "Q",
+        "R",
+        "S",
+        "T",
+        "U",
+        "V",
+        "W",
+        "X",
+        "Y",
+        "Z"
+    },
+    {"Escape", "Tab", "CapsLock", "LShift", "LCtrl", "LSuper", "LAlt"},
+    {"Space", "RAlt", "RSuper", "RCtrl", "RShift", "Enter", "Backspace"},
+    {"BackQuote", "Minus", "Equals", "LeftBracket", "RightBracket"},
+    {"Backslash", "Semicolon", "Quote", "Period", "Slash"}, -- punctuation
+    {"Up", "Down", "Left", "Right", "Insert", "Delete", "Home", "End", "PageUp", "PageDown"} -- navigation
 }
-local numpad = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'Period', 'Divide', 'Multiply', 'Minus', 'Plus' }
-local mouse = { '\238\132\130', '\238\132\131', '\238\132\132' } -- Middle Mouse Button, Mouse Button 4 and 5
+local numpad = {"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "Period", "Divide", "Multiply", "Minus", "Plus"}
+local mouse = {"\238\132\130", "\238\132\131", "\238\132\132"} -- Middle Mouse Button, Mouse Button 4 and 5
 local key_disabled = {description = "Disabled", data = "KEY_DISABLED"}
 keys = {key_disabled}
 for i = 1, #mouse do
@@ -62,7 +91,19 @@ for i = 1, #numpad do
     keys[#keys + 1] = {description = "Numpad " .. key, data = "KEY_KP_" .. key:upper()}
 end
 
+local function addTitle(title)
+    return {
+        name = "snapping_tills",
+        label = title,
+        options = {
+            {description = "", data = 0}
+        },
+        default = 0
+    }
+end
+
 configuration_options = {
+    addTitle("General settings"),
     {
         name = "language",
         label = "Language",
@@ -100,5 +141,107 @@ configuration_options = {
         hover = "Key to toggle intercropping mode",
         options = keys,
         default = "KEY_SEMICOLON"
+    },
+    addTitle("Snap modes"),
+    {
+        name = "enable_off_mode",
+        label = 'Enable "Off" option',
+        hover = 'Enable "Snapping Off" option in rotation\nIf all modes are disabled, this will be the only available option when toggling',
+        options = {
+            {description = "Yes", data = true},
+            {description = "No", data = false}
+        },
+        default = true
+    },
+    {
+        name = "enable_optimized_mode",
+        label = "Enable Optimized mode",
+        hover = "Enable optimized mode in rotation",
+        options = {
+            {description = "Yes", data = true},
+            {description = "No", data = false}
+        },
+        default = false
+    },
+    {
+        name = "enable_4x4_mode",
+        label = "Enable 4x4 mode",
+        hover = "Enable 4x4 mode in rotation",
+        options = {
+            {description = "Yes", data = true},
+            {description = "No", data = false}
+        },
+        default = true
+    },
+    {
+        name = "enable_3x3_mode",
+        label = "Enable 3x3 mode",
+        hover = "Enable 3x3 mode in rotation",
+        options = {
+            {description = "Yes", data = true},
+            {description = "No", data = false}
+        },
+        default = true
+    },
+    {
+        name = "enable_2x2_mode",
+        label = "Enable 2x2 mode",
+        hover = "Enable 2x2 mode in rotation",
+        options = {
+            {description = "Yes", data = true},
+            {description = "No", data = false}
+        },
+        default = false
+    },
+    {
+        name = "enable_hexagon_mode",
+        label = "Enable Hexagon mode",
+        hover = "Enable hexagon mode in rotation",
+        options = {
+            {description = "Yes", data = true},
+            {description = "No", data = false}
+        },
+        default = true
+    },
+    addTitle("Intercropping modes"),
+    {
+        name = "enable_auto_mode",
+        label = "Enable Auto mode",
+        hover = "Enable intercropping Auto mode (inventory-based) in rotation\nIf all modes are disabled, this will be the only available option when toggling",
+        options = {
+            {description = "Yes", data = true},
+            {description = "No", data = false}
+        },
+        default = true
+    },
+    {
+        name = "enable_2_types_mode",
+        label = "Enable 2 types mode",
+        hover = "Enable intercropping 2 types of plants mode in rotation",
+        options = {
+            {description = "Yes", data = true},
+            {description = "No", data = false}
+        },
+        default = true
+    },
+    {
+        name = "enable_3_types_mode",
+        label = "Enable 3 types mode",
+        hover = "Enable intercropping 3 types of plants mode in rotation",
+        options = {
+            {description = "Yes", data = true},
+            {description = "No", data = false}
+        },
+        default = true
+    },
+    {
+        name = "enable_4_types_mode",
+        label = "Enable 4 types mode",
+        hover = "Enable intercropping 4 types of plants mode in rotation",
+        options = {
+            {description = "Yes", data = true},
+            {description = "No", data = false}
+        },
+        default = true
     }
 }

--- a/scripts/components/queuemanager.lua
+++ b/scripts/components/queuemanager.lua
@@ -1,45 +1,7 @@
 -- 250317 VanCa: Add this file to manage tilling / planting on multi tiles
 -- Reference: Action Queue RB3, Bird Painting Scroll
 
-function table_print(tt, indent, done)
-    done = done or {}
-    indent = indent or 0
-    if type(tt) == "table" then
-        local sb = {}
-        for key, value in pairs(tt) do
-            table.insert(sb, string.rep(" ", indent)) -- indent it
-            if "number" == type(key) then
-                table.insert(sb, string.format('%d: "%s" (%s)\n', key, tostring(value), type(value)))
-            else
-                table.insert(sb, string.format('%s = "%s" (%s)\n', tostring(key), tostring(value), type(value)))
-            end
-        end
-        return table.concat(sb)
-    else
-        return tt .. "(type: " .. type(tt) .. ")\n"
-    end
-end
-
-function to_string(tbl)
-    if "nil" == type(tbl) then
-        return tostring(nil)
-    elseif "table" == type(tbl) then
-        return "\n" .. table_print(tbl) .. "\n"
-    elseif "string" == type(tbl) then
-        return tbl
-    else
-        return tostring(tbl) .. "(" .. type(tbl) .. ")"
-    end
-end
-DebugPrint = false and function(...)
-    local msg = "[Snap tillss]"
-    for i = 1, arg.n do
-        msg = msg .. " " .. to_string(arg[i])
-    end
-    print(msg .. "\n")
-end or function()
-        --[[disabled]]
-    end
+local DebugPrint = _G.SnappingTills.DebugPrint
 
 local QueueManager =
     Class(

--- a/scripts/components/snaptillplacer.lua
+++ b/scripts/components/snaptillplacer.lua
@@ -28,10 +28,10 @@ local SnapTillPlacer =
     function(self, inst)
         self.inst = inst
         self.linked = nil
-        self.deployedfarmplant = false
-        self.cachetilepos = nil
-        self.cachesnapmode = nil
-        self.cacheadjacentsoil = nil
+        self.deployed_farm_plant = false
+        self.cache_tile_pos = nil
+        self.cache_snap_mode = nil
+        self.cache_adjacent_soil = nil
         self.visible = true
         self.inst:StartUpdatingComponent(self)
     end
@@ -62,7 +62,7 @@ function SnapTillPlacer:OnUpdate(dt)
         return
     end
 
-    if self.inst.components.snaptiller.snapmode == 0 then
+    if self.inst.components.snaptiller.snap_mode == 0 then
         self:ClearLinked()
         return
     end
@@ -77,16 +77,16 @@ function SnapTillPlacer:OnUpdate(dt)
 
     local activeitem = self.inst.replica.inventory:GetActiveItem()
 
-    -- 250322 VanCa: Change "deployedfarmplant" from a local variable to a component variable
+    -- 250322 VanCa: Change "deployed_farm_plant" from a local variable to a component variable
     -- so that the "placer" events can utilize it.
-    -- "deployedfarmplant" flag is decided in "placer" event (modmain.lua)
+    -- "deployed_farm_plant" flag is decided in "placer" event (modmain.lua)
 
     -- Reset flag
-    if self.deployedfarmplant and not (activeitem and activeitem:HasTag("deployedfarmplant")) then
-        self.deployedfarmplant = false
+    if self.deployed_farm_plant and not (activeitem and activeitem:HasTag("deployedfarmplant")) then
+        self.deployed_farm_plant = false
     end
 
-    if not self.deployedfarmplant then
+    if not self.deployed_farm_plant then
         local equippeditem = self.inst.replica.inventory:GetEquippedItem(EQUIPSLOTS.HANDS)
         if
             not equippeditem or
@@ -104,7 +104,7 @@ function SnapTillPlacer:OnUpdate(dt)
     if TheInput:ControllerAttached() then
         pos = Point(self.inst.entity:LocalToWorldSpace(0, 0, 0))
     else
-        if not self.deployedfarmplant and activeitem ~= nil then
+        if not self.deployed_farm_plant and activeitem ~= nil then
             self:ClearLinked()
             return
         end
@@ -120,27 +120,27 @@ function SnapTillPlacer:OnUpdate(dt)
     local tilex, tiley = TheWorld.Map:GetTileCoordsAtPoint(pos.x, pos.y, pos.z)
     local tile = TheWorld.Map:GetTile(tilex, tiley)
 
-    if self.cachetilepos == nil then
-        self.cachetilepos = {tilex, tiley}
+    if self.cache_tile_pos == nil then
+        self.cache_tile_pos = {tilex, tiley}
     end
 
-    if self.cachesnapmode == nil then
-        self.cachesnapmode = self.inst.components.snaptiller.snapmode
+    if self.cache_snap_mode == nil then
+        self.cache_snap_mode = self.inst.components.snaptiller.snap_mode
     end
 
-    if self.cachesnapmode == 1 then
+    if self.cache_snap_mode == 1 then
         local res =
             self.inst.components.snaptiller:HasAdjacentSoilTile(Point(TheWorld.Map:GetTileCenterPoint(tilex, tiley)))
-        if self.cacheadjacentsoil ~= res then
-            self.cacheadjacentsoil = res
+        if self.cache_adjacent_soil ~= res then
+            self.cache_adjacent_soil = res
             self:ClearLinked()
         end
     end
 
-    if (tile == WORLD_TILES.FARMING_SOIL or tile == WORLD_TILES.QUAGMIRE_SOIL) or self.deployedfarmplant then
+    if (tile == WORLD_TILES.FARMING_SOIL or tile == WORLD_TILES.QUAGMIRE_SOIL) or self.deployed_farm_plant then
         if
-            self.cachetilepos[1] ~= tilex or self.cachetilepos[2] ~= tiley or
-                self.cachesnapmode ~= self.inst.components.snaptiller.snapmode or
+            self.cache_tile_pos[1] ~= tilex or self.cache_tile_pos[2] ~= tiley or
+                self.cache_snap_mode ~= self.inst.components.snaptiller.snap_mode or
                 self.linked == nil
          then
             self:ClearLinked()
@@ -148,8 +148,8 @@ function SnapTillPlacer:OnUpdate(dt)
             for i, v in ipairs(snaplist) do
                 MakeSnapTillPlacer(self, v[1], v[2], i)
             end
-            self.cachetilepos = {tilex, tiley}
-            self.cachesnapmode = self.inst.components.snaptiller.snapmode
+            self.cache_tile_pos = {tilex, tiley}
+            self.cache_snap_mode = self.inst.components.snaptiller.snap_mode
             ApplayVisible(self)
         end
     else
@@ -159,7 +159,7 @@ function SnapTillPlacer:OnUpdate(dt)
     if self.linked ~= nil then
         local can = true
         for _, v in ipairs(self.linked) do
-            if self.deployedfarmplant then
+            if self.deployed_farm_plant then
                 local x, y, z = v.Transform:GetWorldPosition()
                 can = TheWorld.Map:CanTillSoilAtPoint(x, y, z, true)
             else


### PR DESCRIPTION
Add options to disable each individual snap modes and intercropping modes to simplify hotkey rotation.

Remove "Intercropping: Off" option. In Auto mode, when the first slot in inventory is not seeds and not empty ==  intercropping Off.

Make snap tilling/planting easier. Trigger action by clicking on a tile instead of its snap points.

Repeatedly send the action until the location is tilled/planted (useful when the network is unstable).

Update newest version of Hotkey Binding UI.